### PR TITLE
Fix tests in zk_canister_v2 proof module

### DIFF
--- a/backend/zk_canister_v2/src/proof.rs
+++ b/backend/zk_canister_v2/src/proof.rs
@@ -376,10 +376,14 @@ mod tests {
 
     #[test]
     fn test_public_inputs() {
-        let value = Fr::from(100u64);
-        let inputs = create_public_inputs(value.as_int()).expect("Failed to create public inputs");
+        let input = TokenOwnershipInput {
+            balance: 100,
+            min_range: 0,
+            max_range: 200,
+        };
+        let inputs = create_public_inputs(&input).expect("Failed to create public inputs");
         assert_eq!(inputs.len(), 3);
-        assert_eq!(inputs[0], value);
+        assert_eq!(inputs[0], Fr::from(input.balance));
     }
 
     #[test]
@@ -461,12 +465,12 @@ mod tests {
         };
 
         // Test insert and get
-        storage.insert(1, proof.clone(), owner);
+        storage.insert(1, proof.clone());
         assert_eq!(storage.count_for_principal(&owner), 1);
         assert!(storage.get(1).is_some());
 
         // Test remove
-        let removed = storage.remove(1, owner);
+        let removed = storage.remove(1);
         assert!(removed.is_some());
         assert_eq!(storage.count_for_principal(&owner), 0);
         assert!(storage.get(1).is_none());
@@ -500,7 +504,7 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_proof() {
+    fn test_invalid_proof_mismatch() {
         // Test parameters
         let k = 4;
         let input = TokenOwnershipInput {


### PR DESCRIPTION
## Summary
- update public inputs test to use `TokenOwnershipInput`
- fix storage API usage in proof tests
- rename duplicate test to avoid name clash

## Testing
- `cargo check` *(fails: failed to get `halo2_proofs` as a dependency)*