### PR TITLE
Fix typos in zk token declarations

### DIFF
--- a/backend/zk_canister_v2/frontend/zk-proof-client/src/declarations/index.d.ts
+++ b/backend/zk_canister_v2/frontend/zk-proof-client/src/declarations/index.d.ts
@@ -28,7 +28,7 @@ export declare interface CreateActorOptions {
 }
 
 /**
- * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * Initializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
  * @constructs {@link ActorSubClass}
  * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
  * @param {CreateActorOptions} options - see {@link CreateActorOptions}
@@ -44,7 +44,7 @@ export declare const createActor: (
 ) => ActorSubclass<_SERVICE>;
 
 /**
- * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * Initialized Actor using default settings, ready to talk to a canister using its candid interface
  * @constructs {@link ActorSubClass}
  */
 export declare const zk_token_proof: ActorSubclass<_SERVICE>;

--- a/backend/zk_canister_v2/src/declarations/zk_token_proof/index.d.ts
+++ b/backend/zk_canister_v2/src/declarations/zk_token_proof/index.d.ts
@@ -28,7 +28,7 @@ export declare interface CreateActorOptions {
 }
 
 /**
- * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * Initializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
  * @constructs {@link ActorSubClass}
  * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
  * @param {CreateActorOptions} options - see {@link CreateActorOptions}
@@ -44,7 +44,7 @@ export declare const createActor: (
 ) => ActorSubclass<_SERVICE>;
 
 /**
- * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * Initialized Actor using default settings, ready to talk to a canister using its candid interface
  * @constructs {@link ActorSubClass}
  */
 export declare const zk_token_proof: ActorSubclass<_SERVICE>;


### PR DESCRIPTION
## Summary
- correct typo `Intializes` to `Initializes`
- correct typo `Intialized` to `Initialized`

## Testing
- `git log -1 --stat`