### PR TITLE
Enable instant proof expiry in tests

### DIFF
--- a/backend/zk_canister_v2/src/lib.rs
+++ b/backend/zk_canister_v2/src/lib.rs
@@ -39,7 +39,14 @@ const MIN_CYCLES: u64 = 1_000_000_000_000; // 1T cycles
 const PROOF_COST: u64 = 100_000_000_000; // 100B cycles
 const MAX_PROOFS_PER_PRINCIPAL: usize = 10;
 const K: u32 = 8;
-const PROOF_EXPIRY_SECONDS: u64 = 24 * 60 * 60; // 24 hours
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static PROOF_EXPIRY_SECONDS: AtomicU64 = AtomicU64::new(24 * 60 * 60); // 24 hours
+
+/// Adjust proof expiry duration in seconds (primarily for testing).
+pub fn set_proof_expiry_seconds(seconds: u64) {
+    PROOF_EXPIRY_SECONDS.store(seconds, Ordering::Relaxed);
+}
 
 // Add custom random number generator for IC
 use getrandom::register_custom_getrandom;
@@ -157,7 +164,8 @@ pub fn generate_proof(input: TokenOwnershipInput) -> Result<u64, String> {
     let end_time = time();
     let duration_ms = (end_time - start_time) / 1_000_000; // Convert to milliseconds
 
-    let expiry = time() + PROOF_EXPIRY_SECONDS * 1_000_000_000; // Convert to nanoseconds
+    let expiry_seconds = PROOF_EXPIRY_SECONDS.load(Ordering::Relaxed);
+    let expiry = time() + expiry_seconds * 1_000_000_000; // Convert to nanoseconds
     let owner = caller();
 
     // Convert public inputs to hex strings

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,6 +6,7 @@ use zk_canister_v2::{
     init,
     generate_proof,
     verify_proof,
+    set_proof_expiry_seconds,
 };
 
 const LOCAL_REPLICA_URL: &str = "http://localhost:4943";
@@ -56,6 +57,9 @@ async fn test_invalid_range() {
 
 #[tokio::test]
 async fn test_proof_expiry() {
+    // Set expiry to 0 so proofs expire immediately
+    set_proof_expiry_seconds(0);
+
     let input = TokenOwnershipInput {
         balance: 1000,
         min_range: 0,
@@ -63,12 +67,12 @@ async fn test_proof_expiry() {
     };
 
     let proof_id = generate_proof(input).expect("Failed to generate proof");
-    
-    // Wait for proof to expire (in a real test, you'd mock the time)
-    std::thread::sleep(std::time::Duration::from_secs(301)); // 5 minutes + 1 second
-    
+
     let result = verify_proof(proof_id);
     assert!(matches!(result, Err(CanisterError::ProofExpired)));
+
+    // Restore default expiry for other tests
+    set_proof_expiry_seconds(24 * 60 * 60);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- allow adjusting proof expiry using a global atomic value
- use this helper in integration tests to avoid `sleep`

## Testing
- `cargo test --quiet` *(fails: failed to clone halo2_proofs)*