### PR TITLE
Implement token balance verification

### DIFF
--- a/backend/zk_canister_v2/README.md
+++ b/backend/zk_canister_v2/README.md
@@ -45,6 +45,8 @@ const input = {
   balance: 100n,
   min_range: 0n,
   max_range: 1000n,
+  token_canister: Principal.fromText("aaaaa-aa"),
+  token_standard: { ICRC1: null },
 };
 
 const proofId = await actor.generate_proof(input);
@@ -70,6 +72,8 @@ type TokenOwnershipInput = record {
     balance: nat64;
     min_range: nat64;
     max_range: nat64;
+    token_canister: principal;
+    token_standard: variant { ICRC1; ICRC2; DIP20; EXT };
 };
 
 generate_proof: (TokenOwnershipInput) -> (Result<nat64, CanisterError>);

--- a/backend/zk_canister_v2/src/declarations/zk_token_proof/zk_token_proof.did.d.ts
+++ b/backend/zk_canister_v2/src/declarations/zk_token_proof/zk_token_proof.did.d.ts
@@ -17,8 +17,20 @@ export type Result = { 'Ok' : ProofId } |
   { 'Err' : string };
 export type VerifyResult = { 'Ok' : boolean } |
   { 'Err' : string };
+export type TokenStandard =
+  | { 'ICRC1' : null }
+  | { 'ICRC2' : null }
+  | { 'DIP20' : null }
+  | { 'EXT' : null };
+export interface TokenOwnershipInput {
+  'balance' : bigint,
+  'min_range' : bigint,
+  'max_range' : bigint,
+  'token_canister' : Principal,
+  'token_standard' : TokenStandard,
+}
 export interface _SERVICE {
-  'generate_proof' : ActorMethod<[bigint, bigint, bigint], Result>,
+  'generate_proof' : ActorMethod<[TokenOwnershipInput], Result>,
   'get_metrics' : ActorMethod<[], Metrics>,
   'verify_proof' : ActorMethod<[ProofId], VerifyResult>,
 }

--- a/backend/zk_canister_v2/src/declarations/zk_token_proof/zk_token_proof.did.js
+++ b/backend/zk_canister_v2/src/declarations/zk_token_proof/zk_token_proof.did.js
@@ -8,9 +8,22 @@ export const idlFactory = ({ IDL }) => {
     'avg_proof_verification_time_ms' : IDL.Nat64,
   });
   const VerifyResult = IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : IDL.Text });
+  const TokenStandard = IDL.Variant({
+    'ICRC1' : IDL.Null,
+    'ICRC2' : IDL.Null,
+    'DIP20' : IDL.Null,
+    'EXT' : IDL.Null,
+  });
+  const TokenOwnershipInput = IDL.Record({
+    'balance' : IDL.Nat64,
+    'min_range' : IDL.Nat64,
+    'max_range' : IDL.Nat64,
+    'token_canister' : IDL.Principal,
+    'token_standard' : TokenStandard,
+  });
   return IDL.Service({
     'generate_proof' : IDL.Func(
-        [IDL.Nat64, IDL.Nat64, IDL.Nat64],
+        [TokenOwnershipInput],
         [Result],
         [],
       ),

--- a/backend/zk_canister_v2/src/lib.rs
+++ b/backend/zk_canister_v2/src/lib.rs
@@ -22,8 +22,9 @@ use serde::Serialize;
 use crate::{
     circuits::TokenRangeCircuit,
     metrics::{CanisterMetrics, get_metrics},
-    proof::{TokenOwnershipInput, generate_proof_internal, verify_proof_internal},
+    proof::{TokenOwnershipInput, generate_proof_internal, verify_proof_internal, TokenStandard},
     storage::{ProofStorage, StoredProof},
+    token_verification::verify_token_balance,
 };
 
 mod circuits;
@@ -149,8 +150,19 @@ pub fn init() {
 }
 
 #[update]
-pub fn generate_proof(input: TokenOwnershipInput) -> Result<u64, String> {
+pub async fn generate_proof(input: TokenOwnershipInput) -> Result<u64, String> {
     input.validate()?;
+
+    let owner = caller();
+    let verified = verify_token_balance(
+        input.token_canister,
+        owner,
+        input.balance,
+        &input.token_standard,
+    ).await?;
+    if !verified {
+        return Err("Balance verification failed".into());
+    }
 
     let start_time = time();
     let proof_bytes = generate_proof_internal(&input)?;
@@ -158,7 +170,6 @@ pub fn generate_proof(input: TokenOwnershipInput) -> Result<u64, String> {
     let duration_ms = (end_time - start_time) / 1_000_000; // Convert to milliseconds
 
     let expiry = time() + PROOF_EXPIRY_SECONDS * 1_000_000_000; // Convert to nanoseconds
-    let owner = caller();
 
     // Convert public inputs to hex strings
     let public_inputs: Vec<String> = input.to_public_inputs()
@@ -171,6 +182,9 @@ pub fn generate_proof(input: TokenOwnershipInput) -> Result<u64, String> {
         public_inputs,
         expiry,
         owner,
+        input.token_canister,
+        input.token_standard,
+        input.balance,
     );
 
     let proof_id = time();

--- a/backend/zk_canister_v2/src/proof.rs
+++ b/backend/zk_canister_v2/src/proof.rs
@@ -35,6 +35,8 @@ pub struct TokenOwnershipInput {
     pub balance: u64,
     pub min_range: u64,
     pub max_range: u64,
+    pub token_canister: Principal,
+    pub token_standard: TokenStandard,
 }
 
 impl TokenOwnershipInput {

--- a/backend/zk_canister_v2/src/storage.rs
+++ b/backend/zk_canister_v2/src/storage.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use candid::{Decode, Encode};
 use halo2_proofs::halo2curves::bn256::Fr;
+use crate::proof::TokenStandard;
 
 type Memory = VirtualMemory<DefaultMemoryImpl>;
 
@@ -270,15 +271,29 @@ pub struct StoredProof {
     pub public_inputs: Vec<String>,
     pub expiry: u64,
     pub owner: Principal,
+    pub token_canister: Principal,
+    pub token_standard: TokenStandard,
+    pub verified_balance: u64,
 }
 
 impl StoredProof {
-    pub fn new(proof_bytes: Vec<u8>, public_inputs: Vec<String>, expiry: u64, owner: Principal) -> Self {
+    pub fn new(
+        proof_bytes: Vec<u8>,
+        public_inputs: Vec<String>,
+        expiry: u64,
+        owner: Principal,
+        token_canister: Principal,
+        token_standard: TokenStandard,
+        verified_balance: u64,
+    ) -> Self {
         Self {
             proof_bytes,
             public_inputs,
             expiry,
             owner,
+            token_canister,
+            token_standard,
+            verified_balance,
         }
     }
 

--- a/backend/zk_canister_v2/src/tests/integration_tests.rs
+++ b/backend/zk_canister_v2/src/tests/integration_tests.rs
@@ -108,7 +108,9 @@ async fn test_proof_expiration() {
         proof_bytes: vec![],
         public_inputs: vec![],
         owner: Principal::anonymous(),
-        timestamp: 0,
+        token_canister: Principal::anonymous(),
+        token_standard: TokenStandard::ICRC1,
+        verified_balance: 0,
         expiry: 0,
     });
 

--- a/backend/zk_canister_v2/src/zk_token_proof.did
+++ b/backend/zk_canister_v2/src/zk_token_proof.did
@@ -1,7 +1,11 @@
+type TokenStandard = variant { ICRC1; ICRC2; DIP20; EXT; };
+
 type TokenOwnershipInput = record {
   balance: nat64;
   min_range: nat64;
   max_range: nat64;
+  token_canister: principal;
+  token_standard: TokenStandard;
 };
 
 type Result = variant {


### PR DESCRIPTION
## Summary
- add token canister and standard to `TokenOwnershipInput`
- verify the caller's balance cross-canister before generating a proof
- store verified token info with generated proofs
- update Candid interface and TypeScript declarations
- document new input fields in README

## Testing
- `npm test` *(fails: failed to fetch `halo2_proofs` due to network)*